### PR TITLE
mediator pattern

### DIFF
--- a/MississippiMarbles-master/MississippiMarbles-master/Classes/Game.cs
+++ b/MississippiMarbles-master/MississippiMarbles-master/Classes/Game.cs
@@ -14,38 +14,23 @@ namespace MississippiMarbles.Classes
 		private int _turn;
 		public int winnerTurn;
 
-		#region Observer Pattern
-		private readonly List<IGameObserver> _observers = new();
-
-		public void AddObserver(IGameObserver observer)
-		{
-			if (!_observers.Contains(observer))
-				_observers.Add(observer);
-		}
-
-		public void RemoveObserver(IGameObserver observer)
-		{
-			_observers.Remove(observer);
-		}
-
-		private void NotifyGameEnd(Player winner)
-		{
-			foreach (var observer in _observers)
-				observer.onGameEnd(winner);
-		}
-
-		private void NotifyPointsChanged(Player player, int oldPoints, int newPoints)
-		{
-			foreach (var observer in _observers)
-				observer.onPointsChanged(player, oldPoints, newPoints);
-		}
-
-		#endregion
+		private GameMediator _mediator;
 
 		private Game(List<Player> players)
 		{
 			_players = players;
 			_turn = 0;
+			_mediator = new GameMediator();
+		}
+
+		public void AddObserver(IGameObserver observer)
+		{
+			_mediator.AddObserver(observer);
+		}
+
+		public void RemoveObserver(IGameObserver observer)
+		{
+			_mediator.RemoveObserver(observer);
 		}
 
 		public void Start()
@@ -99,7 +84,7 @@ namespace MississippiMarbles.Classes
 							player.setPoints(player.getPoints + player.pointsToAdd);
 							Console.WriteLine("\n*** Turn Summary ***");
 							Console.WriteLine("Player's total score for this turn: " + player.pointsToAdd);
-							NotifyPointsChanged(player, oldPoints, player.getPoints);
+							_mediator.NotifyPointsChanged(player, oldPoints, player.getPoints);
 							Console.WriteLine("\n*** End of Turn ***\n");
 							break;
 						}
@@ -120,7 +105,7 @@ namespace MississippiMarbles.Classes
 						switch (option)
 						{
 							case 1:
-								roll = new Roll(player, _observers); 
+								roll = new Roll(player, _mediator); 
 								roll.TryOpen(player.diceNum);
 								break;
 
@@ -136,7 +121,7 @@ namespace MississippiMarbles.Classes
 									player.setPoints(player.getPoints + player.pointsToAdd);
 									Console.WriteLine("\n*** Turn Summary ***");
 									Console.WriteLine("Player's total score for this turn: " + player.pointsToAdd);
-									NotifyPointsChanged(player, oldPoints, player.getPoints);
+									_mediator.NotifyPointsChanged(player, oldPoints, player.getPoints);
 									Console.WriteLine("\n*** End of Turn ***\n");
 									player.turn = false;
 								}
@@ -157,7 +142,7 @@ namespace MississippiMarbles.Classes
 				{
 					winnerTurn = _turn;
 					gameEnded = true;
-					NotifyGameEnd(player);
+					_mediator.NotifyGameEnd(player);
 				}
 
 				_turn = (_turn + 1) % _players.Count;

--- a/MississippiMarbles-master/MississippiMarbles-master/Classes/GameMediator.cs
+++ b/MississippiMarbles-master/MississippiMarbles-master/Classes/GameMediator.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using MississippiMarbles.Classes;
+using MississippiMarbles.Interfaces;
+
+namespace MississippiMarbles.Classes
+{
+    /// <summary>
+    /// Mediates all game events and manages observers.
+    /// </summary>
+    internal class GameMediator : IGameMediator
+    {
+        private readonly List<IGameObserver> _observers = new();
+
+        public void AddObserver(IGameObserver observer)
+        {
+            if (!_observers.Contains(observer))
+                _observers.Add(observer);
+        }
+
+        public void RemoveObserver(IGameObserver observer)
+        {
+            _observers.Remove(observer);
+        }
+
+        public void NotifyPlayerRoll(Player player, Roll roll)
+        {
+            foreach (var observer in _observers)
+                observer.onPlayerRoll(player, roll);
+        }
+
+        public void NotifyPlayerChoice(Player player, Roll roll)
+        {
+            foreach (var observer in _observers)
+                observer.onPlayerChoice(player, roll);
+        }
+
+        public void NotifyGameEnd(Player winner)
+        {
+            foreach (var observer in _observers)
+                observer.onGameEnd(winner);
+        }
+
+        public void NotifyPointsChanged(Player player, int oldPoints, int newPoints)
+        {
+            foreach (var observer in _observers)
+                observer.onPointsChanged(player, oldPoints, newPoints);
+        }
+    }
+}

--- a/MississippiMarbles-master/MississippiMarbles-master/Classes/Roll.cs
+++ b/MississippiMarbles-master/MississippiMarbles-master/Classes/Roll.cs
@@ -8,7 +8,7 @@ namespace MississippiMarbles.Classes
 {
 	internal class Roll
 	{
-		private readonly List<IGameObserver> _observers;
+		private readonly IGameMediator _mediator;
 		Player player;
 		public int pointsToAdd;
 		public List<int> dice = new List<int>();
@@ -19,27 +19,21 @@ namespace MississippiMarbles.Classes
 			ONE, FIVE, STRAIGHT, TOK1, TOK2, TOK3, TOK4, TOK5, TOK6, FROK, FVOK, SOK
 		}
 
-		public Roll(Player playerTurn, List<IGameObserver> observers)
+		public Roll(Player playerTurn, IGameMediator mediator)
 		{
 			player = playerTurn;
-			_observers = observers;
+			_mediator = mediator;
 		}
 
-
-		#region Observer Pattern
 		private void NotifyPlayerRoll()
 		{
-			foreach (var observer in _observers)
-				observer.onPlayerRoll(player, this);
+			_mediator.NotifyPlayerRoll(player, this);
 		}
 
 		private void NotifyPlayerChoice()
 		{
-			foreach (var observer in _observers)
-				observer.onPlayerChoice(player, this);
+			_mediator.NotifyPlayerChoice(player, this);
 		}
-
-		#endregion
 
 		public void TryOpen(int diceNum)
 		{
@@ -177,7 +171,7 @@ namespace MississippiMarbles.Classes
 							else if (possibilities.ElementAt(option - 1) == Concepts.STRAIGHT)
 							{
 								player.diceNum -= 6;
-								player.setPoints(2000);
+								player.pointsToAdd += 2000;
 								Console.WriteLine("Straight chosen\n");
 								choosingDice = false;
 
@@ -247,7 +241,6 @@ namespace MississippiMarbles.Classes
 								player.diceNum -= 3;
 								player.pointsToAdd += 600;
 								Console.WriteLine("3 sixes chosen\n");
-								dice.Remove(6);
 								dice.Remove(6);
 								dice.Remove(6);
 								dice.Remove(6);

--- a/MississippiMarbles-master/MississippiMarbles-master/Interfaces/IGameMediator.cs
+++ b/MississippiMarbles-master/MississippiMarbles-master/Interfaces/IGameMediator.cs
@@ -1,0 +1,17 @@
+using MississippiMarbles.Classes;
+
+namespace MississippiMarbles.Interfaces
+{
+    /// <summary>
+    /// Interface for mediating game events and managing observers.
+    /// </summary>
+    internal interface IGameMediator
+    {
+        void AddObserver(IGameObserver observer);
+        void RemoveObserver(IGameObserver observer);
+        void NotifyPlayerRoll(Player player, Roll roll);
+        void NotifyPlayerChoice(Player player, Roll roll);
+        void NotifyGameEnd(Player winner);
+        void NotifyPointsChanged(Player player, int oldPoints, int newPoints);
+    }
+}


### PR DESCRIPTION
For this coding kata I have chosen to implement the mediator design pattern into my code. I chose this design pattern because, since I'm already using the observer design pattern, the mediator design pattern can help with making sure components are decoupled. This is one of the improvements to the project as well, before this change, the Roll class needed to know about all the observers, but now with the mediator it handles all observer notifications. This also helps with centralized communication between the classes. That is about it. 